### PR TITLE
Don't justify text on the tour page

### DIFF
--- a/assets/stylesheets/css/main.css
+++ b/assets/stylesheets/css/main.css
@@ -4004,7 +4004,6 @@ input[type="submit"].active {
   hyphens: auto;
   padding-right: 20px;
   padding-left: 20px;
-  text-align: justify;
   -ms-word-break: normal;
   word-break: normal;
 }


### PR DESCRIPTION
In the realm of the subjective: the justified text is unattractive, especially on narrower-width text blocks. Let it be ragged and spaced attractively!